### PR TITLE
fix: prevent job period from breaking mid-text on mobile

### DIFF
--- a/src/components/Job.css
+++ b/src/components/Job.css
@@ -1,5 +1,6 @@
 .Job {
   margin-bottom: var(--size-8);
+  container-type: inline-size;
 }
 
 .Job__company {
@@ -13,10 +14,8 @@
 
 .Job__header {
   display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--size-1) var(--size-2);
+  flex-direction: column;
+  gap: var(--size-1);
   margin-bottom: var(--size-3);
 }
 
@@ -29,5 +28,13 @@
 .Job__period {
   font-size: var(--font-size-1);
   color: var(--fg-minor);
-  white-space: nowrap;
+}
+
+@container (min-width: 400px) {
+  .Job__header {
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--size-2);
+  }
 }


### PR DESCRIPTION
- Add flex-wrap to allow role/period to wrap on narrow screens
- Use white-space: nowrap on period to keep it on one line
- Align items to baseline for better text alignment
- Use space-between to push period to the right